### PR TITLE
Upgrade workspace and example dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,62 +31,62 @@ glory-routing = { version = "0.3.1", path = "crates/routing", default-features =
 glory-hot-reload = { version = "0.3.1", path = "crates/hot-reload" }
 
 anyhow = "1"
-async-trait = "0.1.42"
+async-trait = "0.1.89"
 base64 = "0.22"
 cfg-if = "1"
-config = { version = "0.14", default-features = false, features = ["toml"] }
+config = { version = "0.15", default-features = false, features = ["toml"] }
 educe = "0.6"
 form_urlencoded = "1"
 futures = "0.3"
 futures-channel = { version = "0.3", default-features = true }
-indexmap = "2.0"
+indexmap = "2.14"
 js-sys = "0.3"
 multimap = "0.10"
-once_cell = "1.5.2"
+once_cell = "1.21.4"
 parking_lot = "0.12"
 paste = "1"
 percent-encoding = "2"
 path-slash = "0.2"
 regex = "1"
-salvo = { version = "0.65", default-features = true }
+salvo = { version = "0.93", default-features = true }
 serde = { version = "1" }
 serde_json = { version = "1" }
 smallvec = "1"
-thiserror = "1"
+thiserror = "2"
 tokio = { version = "1", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 tracing = "0.1"
 # tracing-subscriber = "0.3"
 url = "2"
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
-wasm-bindgen-futures = "0.4.31"
+wasm-bindgen-futures = "0.4.71"
 
 # cli dependencies
 ansi_term = "0.12"
-brotli = { version = "3.4", features = ["default"] }
-bytes = "1.4"
-camino = "1.1"
-cargo_metadata = { version = "0.19", features = ["builder"] }
-clap = { version = "4.0", features = ["derive"] }
-derive_more = { version = "1", features = ["display"] }
-dirs = "5.0"
+brotli = { version = "8.0", features = ["default"] }
+bytes = "1.11"
+camino = "1.2"
+cargo_metadata = { version = "0.23", features = ["builder"] }
+clap = { version = "4.6", features = ["derive"] }
+derive_more = { version = "2", features = ["display"] }
+dirs = "6.0"
 dotenvy = "0.15"
 dunce = "1.0"
-flate2 = "1.0"
-flexi_logger = "0.29"
-insta = { version = "1.31.0", features = ["yaml"] }
+flate2 = "1.1"
+flexi_logger = "0.31"
+insta = { version = "1.47.2", features = ["yaml"] }
 itertools = "0.14"
-lightningcss = { version = "1.0.0-alpha.63", features = ["browserslist"] }
+lightningcss = { version = "1.0.0-alpha.71", features = ["browserslist"] }
 log = "0.4"
-notify = "7"
-reqwest = { version = "0.12", features = ["blocking", "native-tls", "json"], default-features = false }
+notify = "8"
+reqwest = { version = "0.13", features = ["blocking", "native-tls", "json"], default-features = false }
 seahash = "4.1"
-semver = "1.0.18"
+semver = "1.0.28"
 tar = "0.4"
-temp-dir = "0.1"
+temp-dir = "0.2"
 wasm-bindgen-cli-support = "0.2"
-which = "5.0"
-zip = { version = "2", default-features = false, features = ["deflate"] }
+which = "8.0"
+zip = { version = "8", default-features = false, features = ["deflate"] }
 zstd = { version = "0.13", default-features = true }
 
 [workspace.dependencies.web-sys]

--- a/crates/cli/src/config/lib_package.rs
+++ b/crates/cli/src/config/lib_package.rs
@@ -38,7 +38,7 @@ impl LibPackage {
 
         let package = packages
             .iter()
-            .find(|p| p.name == *name)
+            .find(|p| p.name.as_str() == name.as_str())
             .ok_or_else(|| anyhow!(r#"Could not find the project lib-package "{name}""#,))?;
 
         let mut features = if !cli.lib_features.is_empty() {

--- a/crates/hot-reload/Cargo.toml
+++ b/crates/hot-reload/Cargo.toml
@@ -23,5 +23,5 @@ rstml = "0.12"
 proc-macro2 = { version = "1", features = ["span-locations", "nightly"] }
 parking_lot = "0.12"
 walkdir = "2"
-camino = "1.1.3"
+camino = "1.2.2"
 indexmap = "2"

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 [dependencies]
 glory = { path = "../../crates/glory", default-features = false, features = ["web-csr"] }
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
-wasm-bindgen-futures = "0.4.31"
+wasm-bindgen-futures = "0.4.71"
 web-sys = "0.3"

--- a/examples/counters/Cargo.toml
+++ b/examples/counters/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 [dependencies]
 glory = { path = "../../crates/glory", default-features = false, features = ["web-csr"] }
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
-wasm-bindgen-futures = "0.4.31"
+wasm-bindgen-futures = "0.4.71"
 web-sys = "0.3"

--- a/examples/hackernews-salvo/Cargo.toml
+++ b/examples/hackernews-salvo/Cargo.toml
@@ -14,14 +14,14 @@ serde = { version = "^1.0", features = ["derive"] }
 serde-aux = { version = "4", default-features = false }
 serde_json = { version = "1", optional = true }
 web-sys = { version = "0.3", features = ["Storage"] }
-salvo = { version = "0.60", default-features = true, optional = true, features = ["serve-static"] }
+salvo = { version = "0.93", default-features = true, optional = true, features = ["serve-static"] }
 tokio = { version = "1", optional = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }
-gloo-net = { version = "0.4", default-features = false, features = ["http", "json"], optional = true }
+gloo-net = { version = "0.7", default-features = false, features = ["http", "json"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 once_cell = "1"
-reqwest = { version = "0.11", optional = true, features = ["json"] }
+reqwest = { version = "0.13", optional = true, features = ["json"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/ssr-modes-salvo/Cargo.toml
+++ b/examples/ssr-modes-salvo/Cargo.toml
@@ -16,11 +16,11 @@ glory = { path = "../../crates/glory", default-features = false, features = ["ro
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 web-sys = { version = "0.3", features = ["Storage"] }
-salvo = { version = "0.63", default-features = true, optional = true, features = ["serve-static"] }
+salvo = { version = "0.93", default-features = true, optional = true, features = ["serve-static"] }
 tokio = { version = "1", optional = true }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-gloo-net = { version = "0.5", default-features = true, optional = true }
+gloo-net = { version = "0.7", default-features = true, optional = true }
 wasm-bindgen = { version = "0.2", optional = true, features = ["enable-interning"] }
 once_cell = "1"
 

--- a/examples/ssr-simple-salvo/Cargo.toml
+++ b/examples/ssr-simple-salvo/Cargo.toml
@@ -15,7 +15,7 @@ glory = { path = "../../crates/glory", default-features = false, features = ["ro
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 web-sys = { version = "0.3", features = ["Storage"] }
-salvo = { version = "0.63", default-features = true, optional = true, features = ["serve-static"] }
+salvo = { version = "0.93", default-features = true, optional = true, features = ["serve-static"] }
 tokio = { version = "1", optional = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }

--- a/examples/tailwind-salvo/Cargo.toml
+++ b/examples/tailwind-salvo/Cargo.toml
@@ -15,7 +15,7 @@ glory = { path = "../../crates/glory", default-features = false, features = ["ro
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 web-sys = { version = "0.3", features = ["Storage"] }
-salvo = { version = "0.58", default-features = true, optional = true, features = ["serve-static"] }
+salvo = { version = "0.93", default-features = true, optional = true, features = ["serve-static"] }
 tokio = { version = "1", optional = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }


### PR DESCRIPTION
## Summary

Brings workspace and example dependencies up to current versions. Builds clean across the workspace and all four salvo-based examples.

### Workspace ([Cargo.toml](Cargo.toml))

Major bumps:
- `salvo` 0.85 → 0.93 (no source changes required)
- `indexmap` 2.0 → 2.14
- `thiserror` 1 → 2
- `config` 0.14 → 0.15
- `notify` 7 → 8
- `zip` 2 → 8
- `brotli` 3 → 8
- `derive_more` 1 → 2
- `dirs` 5 → 6
- `flexi_logger` 0.29 → 0.31
- `which` 5 → 8
- `reqwest` 0.12 → 0.13
- `cargo_metadata` 0.19 → 0.23
- `temp-dir` 0.1 → 0.2
- `wasm-bindgen-futures` 0.4.31 → 0.4.71

Plus numerous patch-level bumps (async-trait 0.1.42 → 0.1.89, once_cell, semver, bytes, camino, clap, flate2, insta, …) to track the latest releases.

### Examples

Several examples pinned salvo versions years behind the workspace; aligned them all to 0.93:

- `examples/tailwind-salvo`: salvo 0.58 → 0.93
- `examples/ssr-simple-salvo`: salvo 0.63 → 0.93
- `examples/ssr-modes-salvo`: salvo 0.63 → 0.93, gloo-net 0.5 → 0.7
- `examples/hackernews-salvo`: salvo 0.60 → 0.93, gloo-net 0.4 → 0.7, reqwest 0.11 → 0.13
- `examples/counter`, `examples/counters`: wasm-bindgen-futures 0.4.31 → 0.4.71

### Code adjustments

`cargo_metadata` 0.23 changed `Package.name` from `String` to a typed wrapper, so [crates/cli/src/config/lib_package.rs](crates/cli/src/config/lib_package.rs) now compares via `.as_str()`.

## Test plan

- [x] `cargo check --workspace` (only pre-existing deprecation warnings on `IndexMap::remove`)
- [x] `cargo check --features web-ssr` in each of `examples/{ssr-simple-salvo,ssr-modes-salvo,hackernews-salvo,tailwind-salvo}`
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)